### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release to PyPi
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/mark-goodall/curvewalk/security/code-scanning/2](https://github.com/mark-goodall/curvewalk/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This can be done either at the global level (affecting all jobs) or for the specific job that lacks it (`build-release`). Since the `publish-release` job already has its own `permissions` block, the best approach is to define permissions globally at the root level of the workflow for consistency and simplicity. The global permissions block should specify the minimum privileges required, such as `contents: read` for checkout operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
